### PR TITLE
Update provider.coffee

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -87,6 +87,11 @@ class BibtexProvider
     @possibleWords = possibleWords
 
   readBibtexFiles: (bibtexFiles) =>
+    
+    # CHANGED make sure that it works even with as single file
+    if typeof bibtexFiles is 'string'
+      bibtexFiles = [bibtexFiles]
+    
     try
       bibtex = []
 


### PR DESCRIPTION
If there is a single bibtex file, change that into an array.

This solves issue #12 -- Here is what happens: when the bibtex field in config is a single line instead of an array, the package is parsing each *letter* or the string as a file.

The fix is simply checking that the bibtex file is a string, and if so, create a single-element arrray