### PR TITLE
Added support for citeproc-yaml

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,10 +1,10 @@
 fs = require "fs"
 
-BibtexProvider = require "./provider"
+ReferenceProvider = require "./provider"
 
 module.exports =
   config:
-    bibtex:
+    references:
       type: 'array'
       default: []
       items:
@@ -19,11 +19,11 @@ module.exports =
   activate: (state) ->
     reload = false
     if state
-      bibtexFiles = atom.config.get "autocomplete-bibtex.bibtex"
-      if not Array.isArray(bibtexFiles)
-        bibtexFiles = [bibtexFiles]
+      referenceFiles = atom.config.get "autocomplete-bibtex.references"
+      if not Array.isArray(referenceFiles)
+        referenceFiles = [referenceFiles]
       # reload everything if any files changed
-      for file in bibtexFiles
+      for file in referenceFiles
         stats = fs.statSync(file)
         if stats.isFile()
           if state.saveTime < stats.mtime.getTime()
@@ -32,21 +32,21 @@ module.exports =
     # Need to distinguish between the Autocomplete provider and the
     # containing class (which holds the serialize fn)
     if state and reload is false
-      @bibtexProvider = atom.deserializers.deserialize(state.provider)
+      @referenceProvider = atom.deserializers.deserialize(state.provider)
       #deserializer produces "undefined" if it fails, so double check
-      if not @bibtexProvider
-        @bibtexProvider = new BibtexProvider()
+      if not @referenceProvider
+        @referenceProvider = new ReferenceProvider()
     else
-      @bibtexProvider = new BibtexProvider()
+      @referenceProvider = new ReferenceProvider()
 
-    @provider = @bibtexProvider.provider
+    @provider = @referenceProvider.provider
 
   deactivate: ->
     @provider.registration.dispose()
 
   serialize: ->
     state = {
-      provider: @bibtexProvider.serialize()
+      provider: @referenceProvider.serialize()
       saveTime: new Date().getTime()
     }
     return state

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -3,10 +3,10 @@ bibtexParse = require "zotero-bibtex-parse"
 fuzzaldrin = require "fuzzaldrin"
 XRegExp = require('xregexp').XRegExp
 titlecaps = require "./titlecaps"
-
+yaml = require "yaml-js"
 
 module.exports =
-class BibtexProvider
+class ReferenceProvider
   ###
   For a while, I intended to continue using XRegExp with this `wordRegex`:
 
@@ -26,20 +26,20 @@ class BibtexProvider
   bibtex = []
 
   atom.deserializers.add(this)
-  @deserialize: ({data}) -> new BibtexProvider(data)
+  @deserialize: ({data}) -> new ReferenceProvider(data)
 
   constructor: (state) ->
     if state and Object.keys(state).length != 0
-      @bibtex = state.bibtex
+      @references = state.references
       @possibleWords = state.possibleWords
     else
-      @buildWordListFromFiles(atom.config.get "autocomplete-bibtex.bibtex")
+      @buildWordListFromFiles(atom.config.get "autocomplete-bibtex.references")
 
-    if @bibtex.length == 0
-      @buildWordListFromFiles(atom.config.get "autocomplete-bibtex.bibtex")
+    if @references.length == 0
+      @buildWordListFromFiles(atom.config.get "autocomplete-bibtex.references")
 
-    atom.config.onDidChange "autocomplete-bibtex.bibtex", (bibtexFiles) =>
-      @buildWordListFromFiles(bibtexFiles)
+    atom.config.onDidChange "autocomplete-bibtex.references", (referenceFiles) =>
+      @buildWordListFromFiles(referenceFiles)
 
     resultTemplate = atom.config.get "autocomplete-bibtex.resultTemplate"
     atom.config.observe "autocomplete-bibtex.resultTemplate", (resultTemplate) =>
@@ -51,7 +51,7 @@ class BibtexProvider
       blacklist: ''
       # inclusionPriority: 1 #FIXME hack to prevent default provider in MD file
       # excludeLowerPriority: true
-      providerblacklist: '' # Give the user the option to configure this.
+      providerblacklist: '' #TODO Give the user the option to configure this.
       requestHandler: (options) =>
         prefix = @prefixForCursor(options.cursor, options.buffer)
 
@@ -89,13 +89,13 @@ class BibtexProvider
     # return provider
 
   serialize: -> {
-    deserializer: 'BibtexProvider'
-    data: { bibtex: @bibtex, possibleWords: @possibleWords }
+    deserializer: 'ReferenceProvider'
+    data: { references: @references, possibleWords: @possibleWords }
   }
 
   buildWordList: () =>
     possibleWords = []
-    for citation in @bibtex
+    for citation in @references
       if citation.entryTags and citation.entryTags.title and (citation.entryTags.author or citation.entryTags.editor)
         citation.entryTags.prettyTitle =
           @prettifyTitle citation.entryTags.title
@@ -123,27 +123,34 @@ class BibtexProvider
 
     @possibleWords = possibleWords
 
-  buildWordListFromFiles: (bibtexFiles) =>
-    @readBibtexFiles(bibtexFiles)
+  buildWordListFromFiles: (referenceFiles) =>
+    @readReferenceFiles(referenceFiles)
     @buildWordList()
 
-  readBibtexFiles: (bibtexFiles) =>
-    # Make sure our list of BibTeX files is an array, even if it's only one file
-    if not Array.isArray(bibtexFiles)
-      bibtexFiles = [bibtexFiles]
-
+  readReferenceFiles: (referenceFiles) =>
+    # Make sure our list of files is an array, even if it's only one file
+    if not Array.isArray(referenceFiles)
+      referenceFiles = [referenceFiles]
     try
-      bibtex = []
-
-      for file in bibtexFiles
+      references = []
+      for file in referenceFiles
+        # What type of file is this?
+        console.warn("'#{file}'")
+        ftype = file.split('.')
+        console.warn("'#{ftype}'")
+        ftype = ftype[ftype.length - 1]
+        console.warn("'#{ftype}'")
         if fs.statSync(file).isFile()
-          parser = new bibtexParse(fs.readFileSync(file, 'utf-8'))
-
-          bibtex = bibtex.concat parser.parse()
+          if ftype is "bib"
+            parser = new bibtexParse(fs.readFileSync(file, 'utf-8'))
+            console.warn("#{parser.parse()}")
+            references = references.concat parser.parse()
+          else
+            alert("SOMETHING ELSE")
         else
           console.warn("'#{file}' does not appear to be a file, so autocomplete-bibtex will not try to parse it.")
 
-      @bibtex = bibtex
+      @references = references
     catch error
       console.error error
 

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -135,18 +135,37 @@ class ReferenceProvider
       references = []
       for file in referenceFiles
         # What type of file is this?
-        console.warn("'#{file}'")
         ftype = file.split('.')
-        console.warn("'#{ftype}'")
         ftype = ftype[ftype.length - 1]
-        console.warn("'#{ftype}'")
+        console.warn("#{ftype}")
+
         if fs.statSync(file).isFile()
+
           if ftype is "bib"
             parser = new bibtexParse(fs.readFileSync(file, 'utf-8'))
-            console.warn("#{parser.parse()}")
             references = references.concat parser.parse()
-          else
-            alert("SOMETHING ELSE")
+            console.log(parser.parse())
+
+          if ftype is "yaml"
+            parsedyaml = yaml.load fs.readFileSync(file, 'utf-8')
+            # Convert yaml to parsed bibtex format
+            yamlref = []
+            for r in parsedyaml
+              # NOTE this is dirty -- but it works for now
+              t_ref = Object
+              t_ref.citationKey = r['id']
+              t_ref.entryType = r['type']
+              t_ref.entryTags = Object
+              # FIXME test
+              t_ref.entryTags.authors = []
+              for a in r['author']:
+                na = Object
+                na.familyName = a['family']
+                na.personalName = a['given']
+                t_ref.entryTags.authors = t_ref.entryTags.authors.concat na
+              yamlref = yamlref.concat t_ref
+              console.log(yamlref)
+
         else
           console.warn("'#{file}' does not appear to be a file, so autocomplete-bibtex will not try to parse it.")
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "fuzzaldrin": "~1.0.0",
     "sugar": "1.4.x",
     "xregexp": "^2.0.0",
+    "yaml-js": "^0.1.1",
     "zotero-bibtex-parse": "git://github.com/apcshields/zotero-bibtex-parse.git#v1.2.0"
   },
   "repository": {


### PR DESCRIPTION
This is a substantial change, but it brings a new functionality. This is not complete, and I don't intend this PR to be mergeable soon; this is an opportunity to comment (see also #31).

I have tested this with two files at once (one in bibtex, one in yaml), and it works seemlessly. Which is good.

There are efforts to be made on the conversion from yaml to the format that is used internally. But as it's not documented, I had to `console.log` the objects and try to infer it from here. What is currently in the code is ~  the bare minimum.

Once this is done, adding support for JSON will not be difficult. In fact, I'd like to write some sort of function to read a citeproc object, then return its representation. This will make it work on yaml and json without a doubt.
