### PR TITLE
remove passage stating autocomplete-plus is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ Adds citation key autocompletion to
 
 You can install autocomplete-bibtex using the Preferences pane.
 
-N.B. autocomplete-bibtex has migrated back to using [autocomplete-plus](https://atom.io/packages/autocomplete-plus),
-so as of version 0.5.0, you once again need to have autocomplete-plus installed.
-See [Usage, step 2] for the extra configuration step this change requires.
 
 ## Usage
 


### PR DESCRIPTION
remove passage stating autocomplete-plus is required, as it is part of Atom by now and not required to install manually.