### PR TITLE
fixes #52 dependency installation behind proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "xregexp": "^2.0.0",
         "atom-space-pen-views": "^2.1.0",
         "yaml-js": "^0.1.3",
-        "zotero-bibtex-parse": "git://github.com/apcshields/zotero-bibtex-parse.git#v1.2.0"
+        "zotero-bibtex-parse": "https://github.com/apcshields/zotero-bibtex-parse.git#v1.2.0"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Installation of the package fail behind tough proxies because they block the use of git to install the zotero-bibtex-parse dependencies. This commit just makes it so that this dependency is installed through https instead.