### PR TITLE
Warn on missing .bib files instead of failing

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -28,11 +28,12 @@ module.exports =
       bibliographyFiles = atom.config.get "autocomplete-bibtex.bibtex"
       # reload everything if any files changed since serialisation
       for file in bibliographyFiles
-        stats = fs.statSync(file)
-        if stats.isFile()
-          if state.saveTime < stats.mtime.getTime()
-            reload = true
-            @saveTime = new Date().getTime()
+        if fs.existsSync(file)
+          stats = fs.statSync(file)
+          if stats.isFile()
+            if state.saveTime < stats.mtime.getTime()
+              reload = true
+              @saveTime = new Date().getTime()
 
     if state and reload is false
       @provider = atom.deserializers.deserialize(state.provider)

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -186,7 +186,7 @@ class ReferenceProvider
     # try
     for file in referenceFiles
       # What type of file is this?
-      if fs.statSync(file).isFile()
+      if fs.existsSync(file) and fs.statSync(file).isFile()
         references = references.concat @readReferenceFile(file)
       else
         console.warn("'#{file}' does not appear to be a file, so autocomplete-bibtex will not try to parse it.")


### PR DESCRIPTION
Currently, missing reference files (e.g., .bib files) cause an exception and parsing the references stops. This patch adds a check to determine if a file exists before it is accessed. If a file does not exists it is ignored and parsing continues with the remaining files.