### PR TITLE
Fix parsing if last key is a single value

### DIFF
--- a/lib/bibtex-lite-worker.js
+++ b/lib/bibtex-lite-worker.js
@@ -338,7 +338,7 @@ class BibtexParser {
       return this.value_quotes()
     }
     let k = this.key()
-    if (k.match("^[0-9]+$"))
+    if (k.match("[0-9]+"))
       return k
     else if (this.months.indexOf(k.toLowerCase()) >= 0)
       return k.toLowerCase()


### PR DESCRIPTION
Crashed on parsing entries where the last key is a single value.
Example:
```
@InProceedings{   ad-swrvn-12,
  author        = {Stefan Albrecht AND Peter Decker},
  title         = {Schnelle Wege zur Restbussimulation: Virtuelle Netzwerke
                  ohne Programmier-Know-how erstellen},
  booktitle     = {Automobil Elektronik},
  month         = jun,
  year          = 2012
}
```