### PR TITLE
Use v0.5.2 of package latex-to-unicode-converter to avoid missing files in v0.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "atom-select-list": "^0.3.2",
     "fuse.js": "^3.2.0",
-    "latex-to-unicode-converter": "^0.5.2",
+    "latex-to-unicode-converter": "0.5.2",
     "untildify": "^3.0.2",
     "yaml-js": "^0.1.3"
   },


### PR DESCRIPTION
A quick fix for issue #107.