### PR TITLE
Fuse weights greater than 1 fix

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -127,11 +127,11 @@ export default class ReferenceProvider {
           },
           {
             name: 'editor',
-            weight: 0.1
+            weight: 0.05
           },
           {
             name: 'journal',
-            weight: 0.1
+            weight: 0.05
           }
         ]
       }


### PR DESCRIPTION
I was getting an error that the sum of the fuse weights add up to more than 1. I reduced the journal and editor weights to fix this error.